### PR TITLE
Aditional links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,7 @@ All Notable changes to `laravel-share` will be documented in this file
 
 ## 2.0.2 - 2018-05-18
 - Adapt tests to changed responses with urlencoded title & message parameters
+
+## 2.0.3 - 2018-08-08
+- Added Pinterest share button ~ More on it's way
+- Changed the default Fontawesome version to v5

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![SensioLabsInsight](https://img.shields.io/sensiolabs/i/dde6008b-ccc6-4a3f-8a98-37d76532f956.svg?style=flat-square)](https://insight.sensiolabs.com/projects/dde6008b-ccc6-4a3f-8a98-37d76532f956)
 [![Total Downloads](https://img.shields.io/packagist/dt/jorenvanhocht/laravel-share.svg?style=flat-square)](https://packagist.org/packages/jorenvanhocht/laravel-share)
 
-Share links exist on almost every page in every project, creating the code for these share links over and over again can be a pain in the ass.
+Share links exist on almost every page in every project. Creating the code for these share links over and over again can be a pain.
 With Laravel Share you can generate these links in just seconds in a way tailored for Laravel.
 
 ### Available services
@@ -52,14 +52,14 @@ Publish the package config & resource files.
 php artisan vendor:publish --provider="Jorenvh\Share\Providers\ShareServiceProvider"
 ```
 
-This will publish the ```laravel-share.php``` config file to your config folder, ```share.js``` in ```public/js/``` and ```laravel-share.php``` in your ```resources/lang/vendor/en/``` folder.
+This will publish the ```laravel-share.php``` config file in to your config folder, ```share.js``` in ```public/js/``` and ```laravel-share.php``` in your ```resources/lang/vendor/en/``` folder.
 
 ### Fontawesome
 
 Since this package relies on Fontawesome, you will have to require it's css, js & fonts in your app.
 You can do that by requesting a embed code [via their website](http://fontawesome.io/get-started/) or by installing it locally in your project.
 
-Laravel share supports Font Awesome v4 and v5, by default v4 is used. You can specify the version you want to use in ```config/laravel-share.php```
+Laravel share supports Font Awesome v4 and v5, by default v5 is used. You can specify the version you want to use in ```config/laravel-share.php```
 
 ### Javascript
 
@@ -106,7 +106,7 @@ Share::page('http://jorenvanhocht.be')->pinterest('pass the media image here', '
 
 ### Sharing the current url
 
-Instead of manually passing an url, you can opt to use the `currentPage` function.
+Instead of manually passing a url, you can opt to use the `currentPage` function.
 
 ```php
 Share::currentPage()->facebook();
@@ -114,7 +114,7 @@ Share::currentPage()->facebook();
 
 ### Creating multiple share Links
 
-If want multiple share links for (multiple) providers you can just chain the methods like this.
+If want multiple share links for (multiple) providers you can just chain the methods like so.
 
 ```php
 Share::page('http://jorenvanhocht.be', 'Share title')
@@ -142,7 +142,7 @@ This will generate the following html
 
 #### Add extra classes and id's to the social buttons
 
-You can simply add extra class(es) or id('s) by passing an array as the third parameter on the page method.
+You can simply add extra class(es) or id(s) by passing an array as the third parameter on the page method.
 
 ```php
 Share::page('http://jorenvanhocht.be', null, ['class' => 'my-class', 'id' => 'my-id'])

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ This will generate the following html
 		<li><a href="https://twitter.com/intent/tweet?text=my share text&amp;url=http://jorenvanhocht.be" class="social-button " id=""><span class="fa fa-twitter"></span></a></li>
 		<li><a href="https://plus.google.com/share?url=http://jorenvanhocht.be" class="social-button " id=""><span class="fa fa-google-plus"></span></a></li>
 		<li><a href="http://www.linkedin.com/shareArticle?mini=true&amp;url=http://jorenvanhocht.be&amp;title=my share text&amp;summary=dit is de linkedin summary" class="social-button " id=""><span class="fa fa-linkedin"></span></a></li>
-		<li><a href="https://www.pinterest.com/pin/create/button/?url=http://jorenvanhocht.be&media=sample.jpg&description=description+goes+here" class="social-button " id=""><span class="fa fa-linkedin"></span></a></li>
+		<li><a href="https://www.pinterest.com/pin/create/button/?url=http://jorenvanhocht.be&media=sample.jpg&description=description+goes+here" class="social-button " id=""><span class="fa fa-pinterest-square"></span></a></li>
 	</ul>
 </div>
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ With Laravel Share you can generate these links in just seconds in a way tailore
 * Twitter
 * Google Plus
 * Linkedin
+* Pinterest
 
 ## Installation
 
@@ -97,6 +98,12 @@ Share::page('http://jorenvanhocht.be')->googlePlus();
 Share::page('http://jorenvanhocht.be', 'Share title')->linkedin('Extra linkedin summary can be passed here')
 ```
 
+#### Pinterest
+
+``` php
+Share::page('http://jorenvanhocht.be')->pinterest('pass the media image here', 'this second parameter is for the description')
+```
+
 ### Sharing the current url
 
 Instead of manually passing an url, you can opt to use the `currentPage` function.
@@ -114,7 +121,8 @@ Share::page('http://jorenvanhocht.be', 'Share title')
 	->facebook()
 	->twitter()
 	->googlePlus()
-	->linkedin('Extra linkedin summary can be passed here');
+	->linkedin('Extra linkedin summary can be passed here')
+	->pinterest('sample.jpg', 'description goes here');
 ```
 
 This will generate the following html
@@ -126,6 +134,7 @@ This will generate the following html
 		<li><a href="https://twitter.com/intent/tweet?text=my share text&amp;url=http://jorenvanhocht.be" class="social-button " id=""><span class="fa fa-twitter"></span></a></li>
 		<li><a href="https://plus.google.com/share?url=http://jorenvanhocht.be" class="social-button " id=""><span class="fa fa-google-plus"></span></a></li>
 		<li><a href="http://www.linkedin.com/shareArticle?mini=true&amp;url=http://jorenvanhocht.be&amp;title=my share text&amp;summary=dit is de linkedin summary" class="social-button " id=""><span class="fa fa-linkedin"></span></a></li>
+		<li><a href="https://www.pinterest.com/pin/create/button/?url=http://jorenvanhocht.be&media=sample.jpg&description=description+goes+here" class="social-button " id=""><span class="fa fa-linkedin"></span></a></li>
 	</ul>
 </div>
 ```

--- a/config/laravel-share.php
+++ b/config/laravel-share.php
@@ -28,6 +28,10 @@ return [
             'uri' => 'http://www.linkedin.com/shareArticle',
             'extra' => ['mini' => 'true']
         ],
+        'pinterest' => [
+            'uri' => 'http://pinterest.com/pin/create/button/',
+            'description' => 'The default Description Fallback'
+        ],
     ],
 
     /*
@@ -41,5 +45,5 @@ return [
     |
     */
 
-    'fontAwesomeVersion' => 4,
+    'fontAwesomeVersion' => 5,
 ];

--- a/resources/lang/en/laravel-share-fa4.php
+++ b/resources/lang/en/laravel-share-fa4.php
@@ -5,5 +5,6 @@ return [
     'twitter' => '<li><a href=":url" class="social-button :class" id=":id"><span class="fa fa-twitter"></span></a></li>',
     'gplus' => '<li><a href=":url" class="social-button :class" id=":id"><span class="fa fa-google-plus"></span></a></li>',
     'linkedin' => '<li><a href=":url" class="social-button :class" id=":id"><span class="fa fa-linkedin"></span></a></li>',
+    'pinterest' => '<li><a href=":url" class="social-button :class" id=":id"><span class="fa fa-pinterest-square"></span></a></li>',
 ];
  

--- a/resources/lang/en/laravel-share-fa5.php
+++ b/resources/lang/en/laravel-share-fa5.php
@@ -5,5 +5,6 @@ return [
     'twitter' => '<li><a href=":url" class="social-button :class" id=":id"><span class="fab fa-twitter"></span></a></li>',
     'gplus' => '<li><a href=":url" class="social-button :class" id=":id"><span class="fab fa-google-plus-g"></span></a></li>',
     'linkedin' => '<li><a href=":url" class="social-button :class" id=":id"><span class="fab fa-linkedin"></span></a></li>',
+    'pinterest' => '<li><a href=":url" class="social-button :class" id=":id"><span class="fab fa-pinterest-square"></span></a></li>',
 ];
  

--- a/src/Share.php
+++ b/src/Share.php
@@ -158,6 +158,21 @@ class Share
         return $this;
     }
 
+
+    public function pinterest($media = '', $description = null)
+    {
+        if (is_null($description)) {
+            $description = config('laravel-share.services.pinterest.description');
+        }
+
+        $base = config('laravel-share.services.pinterest.uri');
+        $url = $base . '?url=' . $this->url . '&media=' . urlencode($media) . '&description=' . urlencode($description);
+
+        $this->buildLink('pinterest', $url);
+
+        return $this;
+    }
+
     /**
      * Build a single link
      *


### PR DESCRIPTION
Added the Pinterest Link. I added only this because I needed this for a project but I will hopefully make more pull requests to add more shareable social media links. For now, I have corrected some of the grammars on the Readme file and also updated the Readme & Change log for you. The `Pinterest()` will take in two parameters. `Pinterest($media, $description)`. `$media` is to add a default media image when sharing and `$description` is for the details. If this is not filled in, media will return null but description will have a default value ("The default Description Fallback").

Hope you merge these and I will continue on keeping this up to date and keep adding more features 👍 :)