### PR TITLE
Remove the Arr dependency

### DIFF
--- a/src/Share.php
+++ b/src/Share.php
@@ -2,8 +2,6 @@
 
 namespace Jorenvh\Share;
 
-use Illuminate\Support\Arr;
-
 class Share
 {
     /**
@@ -227,7 +225,7 @@ class Share
     public function getRawLinks()
     {
         if(count($this->generatedUrls) === 1) {
-            return Arr::first($this->generatedUrls);
+            return (string)current($this->generatedUrls);
         }
 
         return $this->generatedUrls;

--- a/src/Share.php
+++ b/src/Share.php
@@ -220,14 +220,10 @@ class Share
     /**
      * Get the raw generated links.
      *
-     * @return string|array
+     * @return array
      */
     public function getRawLinks()
     {
-        if(count($this->generatedUrls) === 1) {
-            return (string)current($this->generatedUrls);
-        }
-
         return $this->generatedUrls;
     }
 

--- a/tests/RawLinksTest.php
+++ b/tests/RawLinksTest.php
@@ -7,6 +7,27 @@ use Jorenvh\Share\ShareFacade;
 class RawLinksTest extends TestCase
 {
     /** @test */
+    public function it_can_return_empty_array_with_no_links()
+    {
+        $result = ShareFacade::page('https://codeswitch.be', 'My share title')
+            ->getRawLinks();
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    /** @test */
+    public function it_can_return_one_link_as_array()
+    {
+        $result = ShareFacade::page('https://codeswitch.be', 'My share title')
+            ->facebook()
+            ->getRawLinks();
+
+        $this->assertIsArray($result);
+        $this->assertNotEmpty($result);
+    }
+
+    /** @test */
     public function it_can_return_only_facebook_built_link()
     {
         $expected = ['facebook' => 'https://www.facebook.com/sharer/sharer.php?u=https://codeswitch.be'];
@@ -81,27 +102,6 @@ class RawLinksTest extends TestCase
             ->getRawLinks();
 
         $this->assertEquals($expected, $result);
-    }
-
-    /** @test */
-    public function it_can_return_empty_array_with_no_links()
-    {
-        $result = ShareFacade::page('https://codeswitch.be', 'My share title')
-            ->getRawLinks();
-
-        $this->assertIsArray($result);
-        $this->assertEmpty($result);
-    }
-
-    /** @test */
-    public function it_can_return_one_link_as_array()
-    {
-        $result = ShareFacade::page('https://codeswitch.be', 'My share title')
-            ->facebook()
-            ->getRawLinks();
-
-        $this->assertIsArray($result);
-        $this->assertNotEmpty($result);
     }
 
     /** @test */

--- a/tests/RawLinksTest.php
+++ b/tests/RawLinksTest.php
@@ -27,81 +27,68 @@ class RawLinksTest extends TestCase
         $this->assertNotEmpty($result);
     }
 
-    /** @test */
-    public function it_can_return_only_facebook_built_link()
+    /**
+     * @test
+     * @dataProvider provide_data_for_only_link
+     */
+    public function it_can_return_only_facebook_built_link($provider, $url, $title, $expected)
     {
-        $expected = ['facebook' => 'https://www.facebook.com/sharer/sharer.php?u=https://codeswitch.be'];
-        $result = ShareFacade::page('https://codeswitch.be', 'My facebook title')
-            ->facebook()
+        $result = ShareFacade::page($url, $title)
+            ->$provider()
             ->getRawLinks();
 
         $this->assertEquals($expected, $result);
     }
 
-    /** @test */
-    public function it_can_return_only_twitter_built_link()
+    /**
+     * @return array[]
+     */
+    public function provide_data_for_only_link(): array
     {
-        $expected = ['twitter' => 'https://twitter.com/intent/tweet?text=My+twitter+title&url=https://codeswitch.be'];
-        $result = ShareFacade::page('https://codeswitch.be', 'My twitter title')
-            ->twitter()
-            ->getRawLinks();
-
-        $this->assertEquals($expected, $result);
-    }
-
-    /** @test */
-    public function it_can_return_only_linkedin_built_link()
-    {
-        $expected = ['linkedin' => 'https://www.linkedin.com/sharing/share-offsite?mini=true&url=https://codeswitch.be&title=My+linkedin+title&summary='];
-        $result = ShareFacade::page('https://codeswitch.be', 'My linkedin title')
-            ->linkedin()
-            ->getRawLinks();
-
-        $this->assertEquals($expected, $result);
-    }
-
-    /** @test */
-    public function it_can_return_only_whatsapp_built_link()
-    {
-        $expected = ['whatsapp' => 'https://wa.me/?text=https://codeswitch.be'];
-        $result = ShareFacade::page('https://codeswitch.be', 'My whatsapp title')
-            ->whatsapp()
-            ->getRawLinks();
-
-        $this->assertEquals($expected, $result);
-    }
-
-    /** @test */
-    public function it_can_return_only_pinterest_built_link()
-    {
-        $expected = ['pinterest' => 'https://pinterest.com/pin/create/button/?url=https://codeswitch.be'];
-        $result = ShareFacade::page('https://codeswitch.be', 'My pinterest title')
-            ->pinterest()
-            ->getRawLinks();
-
-        $this->assertEquals($expected, $result);
-    }
-
-    /** @test */
-    public function it_can_return_only_reddit_built_link()
-    {
-        $expected = ['reddit' => 'https://www.reddit.com/submit?title=My+reddit+title&url=https://codeswitch.be'];
-        $result = ShareFacade::page('https://codeswitch.be', 'My reddit title')
-            ->reddit()
-            ->getRawLinks();
-
-        $this->assertEquals($expected, $result);
-    }
-
-    /** @test */
-    public function it_can_return_only_telegram_built_link()
-    {
-        $expected = ['telegram' => 'https://telegram.me/share/url?url=https://codeswitch.be&text=My+telegram+title'];
-        $result = ShareFacade::page('https://codeswitch.be', 'My telegram title')
-            ->telegram()
-            ->getRawLinks();
-
-        $this->assertEquals($expected, $result);
+        return [
+            'facebook' => [
+                'facebook',
+                'https://codeswitch.be',
+                'My facebook title',
+                ['facebook' => 'https://www.facebook.com/sharer/sharer.php?u=https://codeswitch.be'],
+            ],
+            'twitter' => [
+                'twitter',
+                'https://codeswitch.be',
+                'My twitter title',
+                ['twitter' => 'https://twitter.com/intent/tweet?text=My+twitter+title&url=https://codeswitch.be'],
+            ],
+            'linkedin' => [
+                'linkedin',
+                'https://codeswitch.be',
+                'My linkedin title',
+                ['linkedin' => 'https://www.linkedin.com/sharing/share-offsite?mini=true&url=https://codeswitch.be&title=My+linkedin+title&summary='],
+            ],
+            'whatsapp' => [
+                'whatsapp',
+                'https://codeswitch.be',
+                'My whatsapp title',
+                ['whatsapp' => 'https://wa.me/?text=https://codeswitch.be'],
+            ],
+            'pinterest' => [
+                'pinterest',
+                'https://codeswitch.be',
+                'My pinterest title',
+                ['pinterest' => 'https://pinterest.com/pin/create/button/?url=https://codeswitch.be'],
+            ],
+            'reddit' => [
+                'reddit',
+                'https://codeswitch.be',
+                'My reddit title',
+                ['reddit' => 'https://www.reddit.com/submit?title=My+reddit+title&url=https://codeswitch.be'],
+            ],
+            'telegram' => [
+                'telegram',
+                'https://codeswitch.be',
+                'My telegram title',
+                ['telegram' => 'https://telegram.me/share/url?url=https://codeswitch.be&text=My+telegram+title'],
+            ],
+        ];
     }
 
     /** @test */

--- a/tests/RawLinksTest.php
+++ b/tests/RawLinksTest.php
@@ -9,78 +9,78 @@ class RawLinksTest extends TestCase
     /** @test */
     public function it_can_return_only_facebook_built_link()
     {
-        $expected = 'https://www.facebook.com/sharer/sharer.php?u=https://codeswitch.be';
+        $expected = ['facebook' => 'https://www.facebook.com/sharer/sharer.php?u=https://codeswitch.be'];
         $result = ShareFacade::page('https://codeswitch.be', 'My share title')
             ->facebook()
             ->getRawLinks();
 
-        $this->assertEquals($expected, (string)$result);
+        $this->assertEquals($expected, $result);
     }
 
     /** @test */
     public function it_can_return_only_twitter_built_link()
     {
-        $expected = 'https://twitter.com/intent/tweet?text=My+share+title&url=https://codeswitch.be';
+        $expected = ['twitter' => 'https://twitter.com/intent/tweet?text=My+share+title&url=https://codeswitch.be'];
         $result = ShareFacade::page('https://codeswitch.be', 'My share title')
             ->twitter()
             ->getRawLinks();
 
-        $this->assertEquals($expected, (string)$result);
+        $this->assertEquals($expected, $result);
     }
 
     /** @test */
     public function it_can_return_only_linkedin_built_link()
     {
-        $expected = 'https://www.linkedin.com/sharing/share-offsite?mini=true&url=https://codeswitch.be&title=My+share+title&summary=';
+        $expected = ['linkedin' => 'https://www.linkedin.com/sharing/share-offsite?mini=true&url=https://codeswitch.be&title=My+share+title&summary='];
         $result = ShareFacade::page('https://codeswitch.be', 'My share title')
             ->linkedin()
             ->getRawLinks();
 
-        $this->assertEquals($expected, (string)$result);
+        $this->assertEquals($expected, $result);
     }
 
     /** @test */
     public function it_can_return_only_whatsapp_built_link()
     {
-        $expected = 'https://wa.me/?text=https://codeswitch.be';
+        $expected = ['whatsapp' => 'https://wa.me/?text=https://codeswitch.be'];
         $result = ShareFacade::page('https://codeswitch.be', 'My share title')
             ->whatsapp()
             ->getRawLinks();
 
-        $this->assertEquals($expected, (string)$result);
+        $this->assertEquals($expected, $result);
     }
 
     /** @test */
     public function it_can_return_only_pinterest_built_link()
     {
-        $expected = 'https://pinterest.com/pin/create/button/?url=https://codeswitch.be';
+        $expected = ['pinterest' => 'https://pinterest.com/pin/create/button/?url=https://codeswitch.be'];
         $result = ShareFacade::page('https://codeswitch.be', 'My share title')
             ->pinterest()
             ->getRawLinks();
 
-        $this->assertEquals($expected, (string)$result);
+        $this->assertEquals($expected, $result);
     }
 
     /** @test */
     public function it_can_return_only_reddit_built_link()
     {
-        $expected = 'https://www.reddit.com/submit?title=My+share+title&url=https://codeswitch.be';
+        $expected = ['reddit' => 'https://www.reddit.com/submit?title=My+share+title&url=https://codeswitch.be'];
         $result = ShareFacade::page('https://codeswitch.be', 'My share title')
             ->reddit()
             ->getRawLinks();
 
-        $this->assertEquals($expected, (string)$result);
+        $this->assertEquals($expected, $result);
     }
 
     /** @test */
     public function it_can_return_only_telegram_built_link()
     {
-        $expected = 'https://telegram.me/share/url?url=https://codeswitch.be&text=My+share+title';
+        $expected = ['telegram' => 'https://telegram.me/share/url?url=https://codeswitch.be&text=My+share+title'];
         $result = ShareFacade::page('https://codeswitch.be', 'My share title')
             ->telegram()
             ->getRawLinks();
 
-        $this->assertEquals($expected, (string)$result);
+        $this->assertEquals($expected, $result);
     }
 
     /** @test */

--- a/tests/RawLinksTest.php
+++ b/tests/RawLinksTest.php
@@ -31,7 +31,7 @@ class RawLinksTest extends TestCase
     public function it_can_return_only_facebook_built_link()
     {
         $expected = ['facebook' => 'https://www.facebook.com/sharer/sharer.php?u=https://codeswitch.be'];
-        $result = ShareFacade::page('https://codeswitch.be', 'My share title')
+        $result = ShareFacade::page('https://codeswitch.be', 'My facebook title')
             ->facebook()
             ->getRawLinks();
 
@@ -41,8 +41,8 @@ class RawLinksTest extends TestCase
     /** @test */
     public function it_can_return_only_twitter_built_link()
     {
-        $expected = ['twitter' => 'https://twitter.com/intent/tweet?text=My+share+title&url=https://codeswitch.be'];
-        $result = ShareFacade::page('https://codeswitch.be', 'My share title')
+        $expected = ['twitter' => 'https://twitter.com/intent/tweet?text=My+twitter+title&url=https://codeswitch.be'];
+        $result = ShareFacade::page('https://codeswitch.be', 'My twitter title')
             ->twitter()
             ->getRawLinks();
 
@@ -52,8 +52,8 @@ class RawLinksTest extends TestCase
     /** @test */
     public function it_can_return_only_linkedin_built_link()
     {
-        $expected = ['linkedin' => 'https://www.linkedin.com/sharing/share-offsite?mini=true&url=https://codeswitch.be&title=My+share+title&summary='];
-        $result = ShareFacade::page('https://codeswitch.be', 'My share title')
+        $expected = ['linkedin' => 'https://www.linkedin.com/sharing/share-offsite?mini=true&url=https://codeswitch.be&title=My+linkedin+title&summary='];
+        $result = ShareFacade::page('https://codeswitch.be', 'My linkedin title')
             ->linkedin()
             ->getRawLinks();
 
@@ -64,7 +64,7 @@ class RawLinksTest extends TestCase
     public function it_can_return_only_whatsapp_built_link()
     {
         $expected = ['whatsapp' => 'https://wa.me/?text=https://codeswitch.be'];
-        $result = ShareFacade::page('https://codeswitch.be', 'My share title')
+        $result = ShareFacade::page('https://codeswitch.be', 'My whatsapp title')
             ->whatsapp()
             ->getRawLinks();
 
@@ -75,7 +75,7 @@ class RawLinksTest extends TestCase
     public function it_can_return_only_pinterest_built_link()
     {
         $expected = ['pinterest' => 'https://pinterest.com/pin/create/button/?url=https://codeswitch.be'];
-        $result = ShareFacade::page('https://codeswitch.be', 'My share title')
+        $result = ShareFacade::page('https://codeswitch.be', 'My pinterest title')
             ->pinterest()
             ->getRawLinks();
 
@@ -85,8 +85,8 @@ class RawLinksTest extends TestCase
     /** @test */
     public function it_can_return_only_reddit_built_link()
     {
-        $expected = ['reddit' => 'https://www.reddit.com/submit?title=My+share+title&url=https://codeswitch.be'];
-        $result = ShareFacade::page('https://codeswitch.be', 'My share title')
+        $expected = ['reddit' => 'https://www.reddit.com/submit?title=My+reddit+title&url=https://codeswitch.be'];
+        $result = ShareFacade::page('https://codeswitch.be', 'My reddit title')
             ->reddit()
             ->getRawLinks();
 
@@ -96,8 +96,8 @@ class RawLinksTest extends TestCase
     /** @test */
     public function it_can_return_only_telegram_built_link()
     {
-        $expected = ['telegram' => 'https://telegram.me/share/url?url=https://codeswitch.be&text=My+share+title'];
-        $result = ShareFacade::page('https://codeswitch.be', 'My share title')
+        $expected = ['telegram' => 'https://telegram.me/share/url?url=https://codeswitch.be&text=My+telegram+title'];
+        $result = ShareFacade::page('https://codeswitch.be', 'My telegram title')
             ->telegram()
             ->getRawLinks();
 

--- a/tests/RawLinksTest.php
+++ b/tests/RawLinksTest.php
@@ -94,13 +94,13 @@ class RawLinksTest extends TestCase
     }
 
     /** @test */
-    public function it_can_return_one_link_as_string()
+    public function it_can_return_one_link_as_array()
     {
         $result = ShareFacade::page('https://codeswitch.be', 'My share title')
             ->facebook()
             ->getRawLinks();
 
-        $this->assertIsString($result);
+        $this->assertIsArray($result);
         $this->assertNotEmpty($result);
     }
 

--- a/tests/RawLinksTest.php
+++ b/tests/RawLinksTest.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Jorenvh\Share\Test;
-
 
 use Jorenvh\Share\ShareFacade;
 
@@ -83,6 +81,16 @@ class RawLinksTest extends TestCase
             ->getRawLinks();
 
         $this->assertEquals($expected, (string)$result);
+    }
+
+    /** @test */
+    public function it_can_return_empty_array_with_no_links()
+    {
+        $result = ShareFacade::page('https://codeswitch.be', 'My share title')
+            ->getRawLinks();
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
     }
 
     /** @test */

--- a/tests/RawLinksTest.php
+++ b/tests/RawLinksTest.php
@@ -94,6 +94,17 @@ class RawLinksTest extends TestCase
     }
 
     /** @test */
+    public function it_can_return_one_link_as_string()
+    {
+        $result = ShareFacade::page('https://codeswitch.be', 'My share title')
+            ->facebook()
+            ->getRawLinks();
+
+        $this->assertIsString($result);
+        $this->assertNotEmpty($result);
+    }
+
+    /** @test */
     public function it_can_return_multiple_built_links_at_once()
     {
         $result = ShareFacade::page('https://codeswitch.be', 'My share title')

--- a/tests/RedditShareTest.php
+++ b/tests/RedditShareTest.php
@@ -17,7 +17,7 @@ class RedditShareTest extends TestCase
         $this->assertEquals($expected, (string)$result);
     }
 
-        /**
+    /**
      * @test
      */
     public function it_can_generate_a_reddit_share_link_with_custom_share_text()


### PR DESCRIPTION
It removes the Arr helper dependency and decouples it a little bit. I don't see any reason to have this dependency here.

Btw, I think that this check for one element on an array in getRawLinks() method (and then returning its string representation) is kind of clumsy, because it increases complexity on the client side. As a client, I have to check the return type before making a decision. I would prefer to get an array all the time and deal with only one type.